### PR TITLE
Can not update MD5 hash after digest is called

### DIFF
--- a/node/node_modules/kpl-deagg/kpl-deagg.js
+++ b/node/node_modules/kpl-deagg/kpl-deagg.js
@@ -10,7 +10,6 @@
 var ProtoBuf = require("protobufjs");
 var crypto = require("crypto");
 require('./constants');
-var md5 = crypto.createHash('md5');
 
 // global AggregatedRecord object which will hold the protocol buffer model
 var AggregatedRecord;
@@ -67,6 +66,7 @@ module.exports.deaggregate = function(kinesisRecord, computeChecksums, perRecord
 
 			if (computeChecksums === true) {
 				// compute a checksum from the serialised protobuf message
+				var md5 = crypto.createHash('md5');
 				md5.update(recordBuffer.slice(4, recordBuffer.length - 16));
 				var calculatedChecksum = md5.digest('base64');
 


### PR DESCRIPTION
Create a new hash so "HashUpdate fail" errors are not encountered when trying to reuse the MD5 hash.